### PR TITLE
SOX-37007 RO: textdiff method encounters error when text contains the word "constructor"

### DIFF
--- a/src/diffr.js
+++ b/src/diffr.js
@@ -497,8 +497,8 @@
     },
 
 		diff: function( partsA, partsB ) {
-			const objA = {};
-			const objB = {};
+			const objA = Object.create(null);
+			const objB = Object.create(null);
 
 			partsB.forEach((part, i) => {
 				if (!objB[part]) {
@@ -555,8 +555,8 @@
 		},
 
     diff2: function( o, n ) {
-      var ns = new Object();
-      var os = new Object();
+      var ns = Object.create(null);
+      var os = Object.create(null);
 
       for ( var i = 0; i < n.length; i++ ) {
         if ( ns[ n[i] ] == null )

--- a/test/test.js
+++ b/test/test.js
@@ -33,4 +33,48 @@ describe('htmldiffer', function() {
 			expect(diff).to.equal("a b <del><img src=\"some_url\" /> </del>c");
 		});
 	});
+
+	describe('textdiff', function() {
+		it('should return unchanged text when both inputs are the same', function() {
+			const response = HtmlDiff.textdiff('input text', 'input text');
+
+			expect(response).to.equal(' input  text\n');
+		});
+
+		it('should mark new text added', function() {
+			const response = HtmlDiff.textdiff('example', 'example text');
+
+			expect(response).to.equal(' example <ins>text\n</ins>');
+		});
+
+		it('should mark text deleted', function() {
+			const response = HtmlDiff.textdiff('example text', 'example');
+
+			expect(response).to.equal(' example\n<del>text\n</del>');
+		});
+
+		it('should identify word changes', function() {
+			const response = HtmlDiff.textdiff('old word', 'new word');
+
+			expect(response).to.equal('<del>old </del><ins>new </ins> word\n');
+		});
+
+		it('should support multiple changes', function() {
+			const response = HtmlDiff.textdiff('first third', 'first second third');
+
+			expect(response).to.equal(' first <ins>second </ins> third\n');
+		});
+
+		it('should respect boundary changes', function() {
+			const response = HtmlDiff.textdiff('start and end', 'start middle and end');
+
+			expect(response).to.equal(' start <ins>middle </ins> and  end\n');
+		});
+
+		it('should handle the word "constructor"', function () {
+			const response = HtmlDiff.textdiff('constructor', 'constructor');
+
+			expect(response).to.equal(' constructor\n');
+		});
+	});
 });


### PR DESCRIPTION
Discovered during investigation of this ticket:

https://auditboard.atlassian.net/browse/SOX-37007

This PR fixes a bug where any strings provided to `HtmlDiff.textdiff` causes an error when they contain the word "constructor".

```
     TypeError: Cannot read properties of undefined (reading 'push')
      at /Users/tbitcomb/workspace/htmldiff.js/src/diffr.js:507:21
      at Array.forEach (<anonymous>)
      at Object.diff (src/diffr.js:503:11)
      at Object.diffString (src/diffr.js:403:40)
      at Diffr.textdiff (src/diffr.js:610:21)
      at Context.<anonymous> (test/test.js:75:30)
```

The reason this is happening is that plain objects are being used for the mappings of tokenized words in the strings being parsed, and the way those objects are being created gives them default properties such as `constructor`, `toString`, etc.  Since the code checks for the existence of a data object for the mapped words, it thinks that it has already assigned said object for "constructor", but it actually hasn't.  This results in the code trying to call `push` on a `rows` array that does not exist on the object it's accessing, which in this case is erroneously the constructor function.

By using `Object.create(null)` to create these mapping objects, the issue is averted because it creates a truly clean object with no default properties.  Using `Map` would probably be better in the future, but `Object.create(null)` results in way fewer changes to the surrounding code.

Some tests mostly-unrelated tests were added for `textdiff` because it seems there are no actual tests for it in the first place.